### PR TITLE
Add a podspec

### DIFF
--- a/edn-objc.podspec
+++ b/edn-objc.podspec
@@ -1,0 +1,17 @@
+# coding: utf-8
+
+Pod::Spec.new do |s|
+
+  s.name         = "edn-objc"
+  s.version      = "0.3.1"
+  s.summary      = "An edn implementation for Objective-C platforms (i.e. iOS, OSX)."
+
+  s.homepage     = "https://github.com/benmosher/edn-objc"
+
+  s.requires_arc = true
+
+  s.license      = "EPL v1"
+  s.author       = { "Ben Mosher" => "me@benmosher.com"}
+  s.source       = { :git => "https://github.com/benmosher/edn-objc.git", :tag => "v0.3.1" }
+  s.source_files  = "edn-objc"
+end


### PR DESCRIPTION
Adds a .podspec file, so edn-objc can be used w/ Cocoapods. I'm a complete noob at Objective C, but this Works For Me. I was able to add 

``` ruby
pod 'edn-objc', :git => 'https://github.com/arohner/edn-objc.git'
```

to my podfile. I haven't done any work to package & publish an official release on cocoapods.org.  
