### PR TITLE
Fix problem while using as CocoaPod

### DIFF
--- a/edn-objc/BMOEDNUnarchiver.m
+++ b/edn-objc/BMOEDNUnarchiver.m
@@ -45,7 +45,7 @@
         return nil;
     }
     if ([obj isKindOfClass:[BMOEDNTaggedElement class]]
-        && [[[obj tag] ns] isEqualToString:@"edn-objc"]) {
+        && [[[(BMOEDNTaggedElement *)obj tag] ns] isEqualToString:@"edn-objc"]) {
         BMOEDNUnarchiver *deeper = [[BMOEDNUnarchiver alloc] initForReadingWithTaggedElement:obj];
         return [deeper decodeRootObject];
     }


### PR DESCRIPTION
Fails when you try to use edn-objc as cocoaPod. Mixes BMOEDNTaggedElement tag and UIView tag. 
